### PR TITLE
parsing command line argument using local encoding

### DIFF
--- a/borderless/main.cpp
+++ b/borderless/main.cpp
@@ -4,7 +4,7 @@
 int main(int argc, char *argv[])
 {
 	QApplication a(argc, argv);
-	MainWindow w(nullptr, argc > 1? argv[1] : "");
+	MainWindow w(nullptr, argc > 1? QString::fromLocal8Bit(argv[1]) : "");
 	w.show();
 	return a.exec();
 }


### PR DESCRIPTION
Otherwise, if the encoding used in argument is not UTF-8 (default in QString constructor), the QString object constructed from it would contain different characters from what are intended.
Then, [`QFileInfo(path).canonicalFilePath()`](https://github.com/unplugred/borderless/blob/be686b5b6d395186acb4251e1a2a0b83ca2895b2/borderless/mainwindow.cpp#L127) in `MainWindow::LoadImage` would return empty, because the wrongly interpreted `path` points to a location that (almost) absolutely does not exist.